### PR TITLE
Fixes issue #8

### DIFF
--- a/FTP/Client.rbbas
+++ b/FTP/Client.rbbas
@@ -246,6 +246,7 @@ Inherits FTP.Connection
 		    Case 226  'Success
 		      TransferComplete(LastVerb.Arguments, True)
 		      Me.CloseData
+		      DataBuffer.Close
 		    Case 425  'No data connection!
 		      Dim lv, la As String
 		      lv = LastVerb.Verb


### PR DESCRIPTION
FTP.Client was failing to close the upload stream, which prevented opening a local file after successfully uploading the same file.
